### PR TITLE
fix: update default `Content-Type` to reflect the one used by `cable_ready`: `text/vnd.cable-ready.json`

### DIFF
--- a/docs/src/_documentation/how_tos/05-integrate-cablecar.md
+++ b/docs/src/_documentation/how_tos/05-integrate-cablecar.md
@@ -38,12 +38,12 @@ mrujs.start({
 Now, any link or form with `data-method="<method>"` or `data-remote="true"` will have the following `Accept` header:
 
 ```js
-"application/vnd.cable-ready.json, */*"
+"text/vnd.cable-ready.json, */*"
 ```
 
 which means any link or form with `data-method="<method>"` or `data-remote="true"` will
 perform an AJAX request, return JSON if it finds a CableCar response from your Rails
-server (or any Ruby server which provides a `Content-Type: application/vnd.cable-ready.json`
+server (or any Ruby server which provides a `Content-Type: text/vnd.cable-ready.json`
 header), and then automatically perform CableCar operations defined in the JSON payload
 return.
 

--- a/docs/src/_documentation/how_tos/05-integrate-cablecar.md
+++ b/docs/src/_documentation/how_tos/05-integrate-cablecar.md
@@ -47,6 +47,16 @@ server (or any Ruby server which provides a `Content-Type: text/vnd.cable-ready.
 header), and then automatically perform CableCar operations defined in the JSON payload
 return.
 
+Note that you can also configure the `Accept` header, by using the `mimeType` option:
+
+```js
+mrujs.start({
+  plugins: [
+    new CableCar(CableReady, { mimeType: "application/vnd.cable-ready.json" })
+  ]
+})
+```
+
 ## [Examples](#examples)
 
 ```html

--- a/plugins/src/cableCar.ts
+++ b/plugins/src/cableCar.ts
@@ -13,7 +13,7 @@ export class CableCar {
 
   constructor (cableReady: CableReady, { mimeType }: CableCarConfig = {}) {
     this.cableReady = cableReady
-    this.mimeType = (mimeType ?? 'application/vnd.cable-ready.json')
+    this.mimeType = mimeType ?? "text/vnd.cable-ready.json";
     this.boundPerform = this.perform.bind(this) as EventListener
   }
 

--- a/test/js/plugins/cableCar.ts
+++ b/test/js/plugins/cableCar.ts
@@ -15,7 +15,7 @@ describe('CableCar with standard config', () => {
   })
 
   it('Should return true for the given content type', () => {
-    assert(cableCar.isCableReadyResponse("application/vnd.cable-ready.json; charset='utf-8'"))
+    assert(cableCar.isCableReadyResponse("text/vnd.cable-ready.json; charset='utf-8'"))
   })
 
   it('Should return true for the given content type', () => {


### PR DESCRIPTION
Since https://github.com/stimulusreflex/cable_ready/pull/260, `cable_ready` changed its Content-Type to `text/vnd.cable-ready.json`. This commit updates the default one used by mrujs to be compatible with `cable_ready`.

Context: https://github.com/stimulusreflex/cable_ready/issues/272

## Status

* Ready, Needs Review
