### PR TITLE
Emit "ujs:afterMorph" event after applying a page morph

### DIFF
--- a/src/navigationAdapter.ts
+++ b/src/navigationAdapter.ts
@@ -277,6 +277,7 @@ function morphHtml (html: string, selector: Element = document.body): void {
   const template = document.createElement('template')
   template.innerHTML = String(html).trim()
   morphdom(selector, template.content, { childrenOnly: true })
+  document.dispatchEvent(new CustomEvent("mrujs:afterMorph"))
 }
 
 function renderError (html: string): void {


### PR DESCRIPTION
## Status

* Needs Review

## Related Issue(s)

-

## Additional Notes

I ran into a case where I was trying to apply some logic after page transitions where the user's session might have changed, and I hit this issue where 95% of the time I could hook into `"turbo:load"` events but 5% of the time (and depending on which page the user was on, and what the controller response was doing) the session change resulted in `mrujs` doing a page morph buuuuut there's no events that gets fired when that happens so there's nothing to listen for. So an event here would be really helpful.

I wasn't sure about the naming; it somewhat breaks from the convention of `"ajax:<eventname>"`, but it feels like this event announcing an mrujs/morphdom update isn't related to ajax? As always, _naming things is hard_ :man_shrugging: 