### PR TITLE
BREAKING_CHANGE: issue with `<head>` content not being morphed correctly

### DIFF
--- a/src/navigationAdapter.ts
+++ b/src/navigationAdapter.ts
@@ -250,13 +250,13 @@ function morphResponse (element: HTMLElement, response: FetchResponseInterface, 
       } else if (errorRenderer === 'morphdom') {
         const selectorString = element.getAttribute('data-ujs-morph-root')
 
-        let selector = document.body
+        let selector = document.documentElement
 
         if (selectorString != null) {
           if (selectorString.trim() === '') {
             selector = element
           } else {
-            selector = document.querySelector(selectorString) ?? document.body
+            selector = document.querySelector(selectorString) ?? document.documentElement
           }
         }
 
@@ -273,10 +273,11 @@ function morphResponse (element: HTMLElement, response: FetchResponseInterface, 
     })
 }
 
-function morphHtml (html: string, selector: Element = document.body): void {
+function morphHtml (html: string, selector: Element = document.documentElement): void {
   const template = document.createElement('template')
   template.innerHTML = String(html).trim()
-  morphdom(selector, template.content, { childrenOnly: true })
+  const content = (selector === document.documentElement) ? template.innerHTML : template.content
+  morphdom(selector, content, { childrenOnly: true })
 }
 
 function renderError (html: string): void {

--- a/test/rails/dummy/app/controllers/morphs_controller.rb
+++ b/test/rails/dummy/app/controllers/morphs_controller.rb
@@ -1,0 +1,7 @@
+class MorphsController < ApplicationController
+  def index; end
+
+  def create
+    redirect_to morphs_path
+  end
+end

--- a/test/rails/dummy/app/views/layouts/application.html.erb
+++ b/test/rails/dummy/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title>Dummy</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="morph-meta-test" content="<%= SecureRandom.hex(8) %>">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/test/rails/dummy/app/views/morphs/index.html.erb
+++ b/test/rails/dummy/app/views/morphs/index.html.erb
@@ -1,0 +1,5 @@
+<h1>Morph Test</h1>
+
+<div>
+  <a href="<%= morphs_path %>" data-remote="true" data-method="post" id="morph-link">It's morphin' time!</a>
+</div>

--- a/test/rails/dummy/config/routes.rb
+++ b/test/rails/dummy/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
 
   resources :posts
   resources :remote_links
+  resources :morphs
 end

--- a/test/rails/dummy/test/system/morph_test.rb
+++ b/test/rails/dummy/test/system/morph_test.rb
@@ -1,0 +1,33 @@
+require "application_system_test_case"
+
+class MorphTest < ApplicationSystemTestCase
+  test "morphs <body> content" do
+    visit morphs_path
+
+    assert_selector "h1", text: "Morph Test"
+    page.execute_script("document.querySelector('h1').textContent = 'Morph Me'")
+    assert_selector "h1", text: "Morph Me"
+
+    click_link "morph-link"
+
+    refute_selector "h1", text: "Morph Me"
+    assert_selector "h1", text: "Morph Test"
+  end
+
+  test "morphs <head> content" do
+    visit morphs_path
+
+    unique_meta_tag = page.find("meta[name='morph-meta-test']", visible: false)[:content]
+
+    page.execute_script("document.querySelector('h1').textContent = 'Morph Me'")
+    click_link "morph-link"
+    assert_selector "h1", text: "Morph Test"
+
+    new_unique_meta_tag = page.find("meta[name='morph-meta-test']", visible: false)[:content]
+
+    refute_equal unique_meta_tag, new_unique_meta_tag
+
+    assert_css "head meta[name='morph-meta-test']", visible: false
+    refute_css "body meta[name='morph-meta-test']", visible: false
+  end
+end


### PR DESCRIPTION
## Status

* Needs Review

## Related Issue(s)

-

## Additional Notes

There's currently a weird bug in the way that `mrujs` mophs the html response on to the current page, but it's a bit silent because it tends to not actually break anything too important. The response contains a full HTML document, but when it's applied to the current page via morphdom, content inside the response's `<head>` element gets injected into the `<body>` in the DOM in a weird way. The DOM looks like this after `morphHTML` is called:

![Screenshot from 2023-05-24 20-18-40](https://github.com/KonnorRogers/mrujs/assets/9029026/be390536-0159-4eff-a716-547aa243287a)

So the elements that were meant to be written to the head get written into the body and there's duplicates. Most of the time this doesn't actually break anything and the problem gets cleaned up after the user navigates away from the page... except if you happen to be using meta tags in weird ways to pass bits of data that are then used by Stimulus... in which case it definitely does break things a bit. Checked in Firefox and Chrome, same results.

I wouldn't say I'm a morphdom expert, so I'm not sure this is 100% the way to go in this case for a full page morph, but it definitely fixes the bug, both `<head>` and `<body>` content are now morphed correctly. I also added a couple of (admittedly somewhat strange-looking) regression tests to cover this case and check that the morphdom calls are updating all the things as expected.
